### PR TITLE
SP-109: Support legacy driving models with Navigate on openpilot (NoO)

### DIFF
--- a/services.py
+++ b/services.py
@@ -76,6 +76,8 @@ services: dict[str, tuple] = {
   "navInstruction": (True, 1., 10),
   "navRoute": (True, 0.),
   "navThumbnail": (True, 0.),
+  "navModelDEPRECATED": (True, 2., 4.),
+  "mapRenderStateDEPRECATED": (True, 2., 1.),
   "uiPlan": (True, 20., 40.),
   "qRoadEncodeIdx": (False, 20.),
   "userFlag": (True, 0., 1),


### PR DESCRIPTION
Closes `sunnypilot:SP-109`